### PR TITLE
a11y_fix: text-link

### DIFF
--- a/amdxg/amdxg-components/src/Layout.tsx
+++ b/amdxg/amdxg-components/src/Layout.tsx
@@ -58,7 +58,7 @@ export function Footer() {
         created by&nbsp;
         <a
           href="https://github.com/mizchi/amdx"
-          className="underline text-blue-500 hover:no-underline"
+          className="underline text-blue-400 hover:no-underline"
         >
           amdxg
         </a>

--- a/amdxg/amdxg-components/src/Layout.tsx
+++ b/amdxg/amdxg-components/src/Layout.tsx
@@ -58,7 +58,7 @@ export function Footer() {
         created by&nbsp;
         <a
           href="https://github.com/mizchi/amdx"
-          className="text-blue-500 hover:text-blue-800"
+          className="text-blue-500"
         >
           amdxg
         </a>

--- a/amdxg/amdxg-components/src/Layout.tsx
+++ b/amdxg/amdxg-components/src/Layout.tsx
@@ -58,7 +58,7 @@ export function Footer() {
         created by&nbsp;
         <a
           href="https://github.com/mizchi/amdx"
-          className="text-blue-500"
+          className="underline text-blue-500 hover:no-underline"
         >
           amdxg
         </a>

--- a/amdxg/amdxg-components/src/Link.tsx
+++ b/amdxg/amdxg-components/src/Link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 export function Link(props: { href: string; children: React.ReactNode }) {
   return (
-    <a className="text-blue-500 hover:text-blue-800" href={props.href}>
+    <a className="text-blue-700 hover:text-blue-800" href={props.href}>
       {props.children}
     </a>
   );

--- a/amdxg/amdxg-components/src/Link.tsx
+++ b/amdxg/amdxg-components/src/Link.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 export function Link(props: { href: string; children: React.ReactNode }) {
   return (
-    <a className="text-blue-700 hover:text-blue-800" href={props.href}>
+    <a className="underline text-blue-700 hover:no-underline" href={props.href}>
       {props.children}
     </a>
   );

--- a/amdxg/amdxg-components/src/PageList.tsx
+++ b/amdxg/amdxg-components/src/PageList.tsx
@@ -11,7 +11,7 @@ export function PageList(props: { pages: Page[] }) {
           <div key={index}>
             <span>{formatted}</span>: &nbsp;
             <a
-              className="text-blue-500 hover:text-blue-800"
+              className="text-blue-700 hover:text-blue-800"
               href={"/" + page.slug}
             >
               {page.title}

--- a/amdxg/amdxg-components/src/PageList.tsx
+++ b/amdxg/amdxg-components/src/PageList.tsx
@@ -11,7 +11,7 @@ export function PageList(props: { pages: Page[] }) {
           <div key={index}>
             <span>{formatted}</span>: &nbsp;
             <a
-              className="text-blue-700 hover:text-blue-800"
+              className="underline text-blue-700 hover:no-underline"
               href={"/" + page.slug}
             >
               {page.title}


### PR DESCRIPTION
- テキストリンクのコントラスト比が弱かったのでコントラスト比高いのに変更
  - <img width="654" alt="Screen Shot 2020-05-19 at 22 50 25" src="https://user-images.githubusercontent.com/1996642/82336036-08c7ca00-9a25-11ea-9266-0e8bc07041fa.png">
  - https://tailwindcss.com/docs/text-color/
- 700になったのでhover時の800と色の差が大きくなくなるので`underline`でリンクホバーの可否を変更
  - https://tailwindcss.com/docs/text-decoration/
- Lighthouseのアクセシビリティ判定で100点取れるように
  - 詳細ページのamp-social-shareはこちらでいかんともしがたいのでスルー
  - ![Screen Shot 2020-05-19 at 23 00 13](https://user-images.githubusercontent.com/1996642/82335611-8d661880-9a24-11ea-9d4e-ae6289d5162f.png)

