### PR TITLE
Trim URL in rss

### DIFF
--- a/amdxg/amdxg-cli/src/index.ts
+++ b/amdxg/amdxg-cli/src/index.ts
@@ -103,9 +103,7 @@ function buildRSS(flags: {}) {
           return `
         <item>
           <title>${escape(p.title)}</title>
-          <link>
-            ${path.join(amdxgConfig.host, p.slug)}
-          </link>
+          <link>${path.join(amdxgConfig.host, p.slug)}</link>
           <pubDate>${new Date(p.created).toISOString()}</pubDate>
           <description>
           <![CDATA[]]>


### PR DESCRIPTION
To trim URLs because these in [`rss.xml`](https://mizchi.dev/rss.xml) include spaces now.